### PR TITLE
Fix TypeScript errors preventing Netlify build

### DIFF
--- a/src/components/DemoEmbed.tsx
+++ b/src/components/DemoEmbed.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Users, Target, CheckCircle, Clock, TrendingUp, Settings, Bell, Star, Trophy, MessageSquare } from 'lucide-react';
+import { Users, Target, CheckCircle, TrendingUp, Settings, Bell, Star, Trophy, MessageSquare } from 'lucide-react';
 
 const DemoEmbed: React.FC = () => {
   const [currentStep, setCurrentStep] = useState(0);

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -9,7 +9,7 @@ interface RouteGuardProps {
 
 const RouteGuard: React.FC<RouteGuardProps> = ({ children }) => {
   const { user, loading: authLoading } = useAuth();
-  const { profile, loading: profileLoading, shouldRedirectToGetStarted } = useProfile();
+  const { loading: profileLoading, shouldRedirectToGetStarted } = useProfile();
 
   if (authLoading || profileLoading) {
     return (

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -15,7 +15,7 @@ export const useAuth = () => {
 
     // Listen for auth changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
+      async (_event, session) => {
         setUser(session?.user ?? null);
         setLoading(false);
       }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Target, Users, TrendingUp, Settings, Bell, LogOut, CreditCard, Calendar, Star, Trophy } from 'lucide-react';
+import { Target, Users, TrendingUp, Settings, Bell, LogOut, Calendar, Trophy } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { useProfile } from '../hooks/useProfile';
 

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Users, Target, CheckCircle, Clock, TrendingUp, Settings, Plus, Eye, MessageSquare, Star, Trophy, Bell } from 'lucide-react';
+import { Users, Target, CheckCircle, Clock, TrendingUp, Settings, Plus, MessageSquare, Star, Trophy, Bell } from 'lucide-react';
 
 const DemoPage: React.FC = () => {
   const [currentStep, setCurrentStep] = useState(0);

--- a/src/pages/GetStartedPage.tsx
+++ b/src/pages/GetStartedPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Target, CheckCircle, Users, TrendingUp } from 'lucide-react';
+import { Target, CheckCircle } from 'lucide-react';
 
 const GetStartedPage: React.FC = () => {
   const [selectedPlan, setSelectedPlan] = useState<'standard' | 'premium'>('premium');

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Target, CheckCircle, Users, TrendingUp, Clock, Star, Eye } from 'lucide-react';
+import { Target, CheckCircle, Users, TrendingUp, Clock, Star } from 'lucide-react';
 import Header from '../components/Header';
 import DemoEmbed from '../components/DemoEmbed';
 

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Target, Eye, EyeOff, AlertCircle } from 'lucide-react';
+import { Eye, EyeOff, AlertCircle } from 'lucide-react';
 import Header from '../components/Header';
 import { useAuth } from '../hooks/useAuth';
 

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Target, Eye, EyeOff, AlertCircle, CheckCircle } from 'lucide-react';
+import { Eye, EyeOff, AlertCircle, CheckCircle } from 'lucide-react';
 import Header from '../components/Header';
 import { useAuth } from '../hooks/useAuth';
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_STRIPE_PUBLISHABLE_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+


### PR DESCRIPTION
## Summary
- remove unused imports and variables across components and pages
- provide Vite environment typings so `import.meta.env` is recognized
- ignore unused auth state change event parameter

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b54345c648832a8ba36117a3510e75