### PR TITLE
chore: remove unused Target icon

### DIFF
--- a/src/pages/GetStartedPage.tsx
+++ b/src/pages/GetStartedPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Target, CheckCircle } from 'lucide-react';
+import { CheckCircle } from 'lucide-react';
 import Header from '../components/Header';
 
 const GetStartedPage: React.FC = () => {


### PR DESCRIPTION
## Summary
- fix: remove unused Target icon from Get Started page

## Testing
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b62c7a4494832a82c1c6b06bbffd3f