### PR TITLE
Fix password reset flow and show login confirmation

### DIFF
--- a/src/pages/GetStartedPage.tsx
+++ b/src/pages/GetStartedPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Target, CheckCircle } from 'lucide-react';
+import { CheckCircle } from 'lucide-react';
 import Header from '../components/Header';
 
 const GetStartedPage: React.FC = () => {

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Target, AlertCircle, CheckCircle } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import { supabase } from '../lib/supabase';
 
 const ResetPasswordPage: React.FC = () => {
   const [password, setPassword] = useState('');
@@ -9,8 +10,24 @@ const ResetPasswordPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
+  const [checking, setChecking] = useState(true);
+  const [sessionValid, setSessionValid] = useState(false);
 
   const { updatePassword, signOut } = useAuth();
+
+  useEffect(() => {
+    const verifySession = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (session?.user) {
+        setSessionValid(true);
+      }
+      setChecking(false);
+    };
+
+    verifySession();
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -18,6 +35,11 @@ const ResetPasswordPage: React.FC = () => {
 
     if (password !== confirmPassword) {
       setError('Passwords do not match');
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters long');
       return;
     }
 
@@ -39,6 +61,38 @@ const ResetPasswordPage: React.FC = () => {
     }
   };
 
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-blue-50 flex items-center justify-center px-4">
+        <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 text-center">
+          <div className="animate-spin w-8 h-8 border-2 border-emerald-500 border-t-transparent rounded-full mx-auto"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!sessionValid) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-blue-50 flex items-center justify-center px-4">
+        <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 text-center">
+          <div className="w-16 h-16 bg-red-500 rounded-full flex items-center justify-center mx-auto mb-6">
+            <AlertCircle className="w-8 h-8 text-white" />
+          </div>
+          <h2 className="text-2xl font-bold text-slate-900 mb-4">Invalid or Expired Link</h2>
+          <p className="text-slate-600 mb-6">
+            Your password reset link is invalid or has expired. Please request a new reset email.
+          </p>
+          <Link
+            to="/forgot-password"
+            className="inline-block bg-emerald-500 text-white px-6 py-3 rounded-lg font-semibold hover:bg-emerald-600 transition-colors duration-200"
+          >
+            Request New Reset Link
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   if (success) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-blue-50 flex items-center justify-center px-4">
@@ -51,7 +105,7 @@ const ResetPasswordPage: React.FC = () => {
             Your password has been reset successfully. You can now sign in with your new password.
           </p>
           <Link
-            to="/signin"
+            to="/signin?message=Password%20reset%20successfully"
             className="inline-block bg-emerald-500 text-white px-6 py-3 rounded-lg font-semibold hover:bg-emerald-600 transition-colors duration-200"
           >
             Go to Sign In

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { Eye, EyeOff, AlertCircle } from 'lucide-react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Eye, EyeOff, AlertCircle, CheckCircle } from 'lucide-react';
 import Header from '../components/Header';
 import { useAuth } from '../hooks/useAuth';
 
@@ -13,6 +13,8 @@ const SigninPage: React.FC = () => {
   
   const { signIn } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const message = searchParams.get('message');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -52,6 +54,12 @@ const SigninPage: React.FC = () => {
 
             <div className="bg-white rounded-2xl shadow-xl border border-slate-200 p-8">
               <form onSubmit={handleSubmit} className="space-y-6">
+                {message && (
+                  <div className="bg-green-50 border border-green-200 rounded-lg p-4 flex items-center space-x-3">
+                    <CheckCircle className="w-5 h-5 text-green-500 flex-shrink-0" />
+                    <p className="text-green-700 text-sm">{message}</p>
+                  </div>
+                )}
                 {error && (
                   <div className="bg-red-50 border border-red-200 rounded-lg p-4 flex items-center space-x-3">
                     <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0" />


### PR DESCRIPTION
## Summary
- Validate password reset sessions and enforce password length
- Show success alert on sign-in when coming from reset
- Clean up unused import in GetStartedPage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b62e7b918c832a98b72300175d5860